### PR TITLE
投稿・食べたいタブがコンテンツから離れるのを修正

### DIFF
--- a/mypage.html
+++ b/mypage.html
@@ -31,19 +31,20 @@
         </div>        
     </div>
 
-    <div class="tabs">
-        <p class="tab selected">投稿</p>
-        <p class="tab">食べたい</p>
+    <div class="contents">
+      <div class="tabs">
+          <p class="tab selected">投稿</p>
+          <p class="tab">食べたい</p>
+      </div>
+      <div class="posts">
+          <img class="post-image" src='sample.jpg' alt='投稿画像'>
+          <img class="post-image" src='sample.jpg' alt='投稿画像'>
+          <img class="post-image" src='sample.jpg' alt='投稿画像'>
+          <img class="post-image" src='sample.jpg' alt='投稿画像'>
+          <img class="post-image" src='sample.jpg' alt='投稿画像'>
+          <img class="post-image" src='sample.jpg' alt='投稿画像'>
+      </div>
     </div>
-    <div class="posts">
-        <img class="post-image" src='sample.jpg' alt='投稿画像'>
-        <img class="post-image" src='sample.jpg' alt='投稿画像'>
-        <img class="post-image" src='sample.jpg' alt='投稿画像'>
-        <img class="post-image" src='sample.jpg' alt='投稿画像'>
-        <img class="post-image" src='sample.jpg' alt='投稿画像'>
-        <img class="post-image" src='sample.jpg' alt='投稿画像'>
-    </div>
-
     <div class="float-button">
         <a href='#'>検索</a>
         <a href='#'>投稿</a>

--- a/style.css
+++ b/style.css
@@ -15,6 +15,11 @@ body{
     float: left;
     margin-left: 20px;
 }
+.user-info::after{
+  content: "";
+  display: block;
+  clear: both;
+}
 img.user-icon{
     width: 200px;
     height: 200px;

--- a/style.css
+++ b/style.css
@@ -33,8 +33,13 @@ img.user-icon{
     height: 200px;
     padding-left: 250px;
 }
+.contents{
+  position: relative;
+}
 .tabs{
-    float: right;
+    position: absolute;
+    top: -30px;
+    right: 30px;
     height: 30px;
 }
 .tab{
@@ -52,7 +57,6 @@ img.user-icon{
     background-color: white;
 }
 .posts{
-    clear: both;
     margin-top: 0;
     padding: 7px;
     border-top: solid 1px black;


### PR DESCRIPTION
- 問題点
次のページを参照 .user-info .leftはfloatしているが、floatすると親要素（.user-info）のサイズに認識されなくなる。よって投稿・食べたいタブが一段上にずれ込みコンテンツとくっつかない。画面サイズが小さい場合は.user-infoのサイズによらずタブが下にずれ込むため問題が無い。 
- 解消方法　
float要素の親要素に親要素のサイズに認識される見えないボックスを配置することでサイズを修正。詳しく次のURLを参照。 https://qiita.com/sanstktkrsyhsk/items/8298a47683fd67ad6299